### PR TITLE
simplified exception handling

### DIFF
--- a/src/pythonpancakes/api.py
+++ b/src/pythonpancakes/api.py
@@ -22,21 +22,9 @@ class PancakeSwapAPI:
         :param request_url: str
         """
         with requests.Session() as session:
-            try:
-                response = session.get(request_url, timeout=self.request_timeout)
-            except requests.exceptions.RequestException:
-                raise
-
-            try:
-                response.raise_for_status()
-                return json.loads(response.content.decode('utf-8'))
-            except Exception as err:
-                try:
-                    content = json.loads(response.content.decode('utf-8'))
-                    raise ValueError(content)
-                except json.decoder.JSONDecodeError:
-                    pass
-                raise
+            response = session.get(request_url, timeout=self.request_timeout)
+            response.raise_for_status()
+            return json.loads(response.content.decode('utf-8'))
 
     def summary(self):
         """
@@ -54,14 +42,11 @@ class PancakeSwapAPI:
         :return: Dict
         """
         if address:
-            try:
-                # Trim any whitespace from address
-                address = address.replace(' ', '')
-                # Validate provided address matches ERC20 format - does not check if the address is valid on chain!
-                if not re.match("^0x([A-Fa-f0-9]{40})$", address):
-                    raise ValueError(address)
-            except ValueError:
-                return "Provided address hash is not in a valid format"
+            # Trim any whitespace from address
+            address = address.replace(' ', '')
+            # Validate provided address matches ERC20 format - does not check if the address is valid on chain!
+            if not re.match("^0x([A-Fa-f0-9]{40})$", address):
+                raise ValueError(f"Provided address hash ({address}) is not in a valid format.")
 
         url = f"{self.base_url}tokens{'/' + address if address is not None else ''}"
         return self.__get(url)

--- a/src/pythonpancakes/api.py
+++ b/src/pythonpancakes/api.py
@@ -58,4 +58,3 @@ class PancakeSwapAPI:
         """
         url = f"{self.base_url}pairs"
         return self.__get(url)
-        

--- a/src/pythonpancakes/api.py
+++ b/src/pythonpancakes/api.py
@@ -21,6 +21,9 @@ class PancakeSwapAPI:
         retries = Retry(total=3, backoff_factor=0.5, status_forcelist=[502, 503, 504])
         self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
+    def __enter__(self):
+        return self
+
     def __exit__(self):
         self.session.close()
 
@@ -29,21 +32,9 @@ class PancakeSwapAPI:
         GET request wrapper
         :param request_url: str
         """
-        try:
-            response = self.session.get(request_url, timeout=self.request_timeout)
-        except requests.exceptions.RequestException:
-            raise
-
-        try:
-            response.raise_for_status()
-            return json.loads(response.content.decode('utf-8'))
-        except Exception as err:
-            try:
-                content = json.loads(response.content.decode('utf-8'))
-                raise ValueError(content)
-            except json.decoder.JSONDecodeError:
-                pass
-            raise
+        response = self.session.get(request_url, timeout=self.request_timeout)
+        response.raise_for_status()
+        return json.loads(response.content.decode('utf-8'))
 
     def summary(self):
         """
@@ -61,14 +52,11 @@ class PancakeSwapAPI:
         :return: Dict
         """
         if address:
-            try:
-                # Trim any whitespace from address
-                address = address.replace(' ', '')
-                # Validate provided address matches ERC20 format - does not check if the address is valid on chain!
-                if not re.match("^0x([A-Fa-f0-9]{40})$", address):
-                    raise ValueError(address)
-            except ValueError:
-                return "Provided address hash is not in a valid format"
+            # Trim any whitespace from address
+            address = address.replace(' ', '')
+            # Validate provided address matches ERC20 format - does not check if the address is valid on chain!
+            if not re.match("^0x([A-Fa-f0-9]{40})$", address):
+                raise ValueError(f"Provided address hash ({address}) is not in a valid format.")
 
         url = f"{self.base_url}tokens{'/' + address if address is not None else ''}"
         return self.__get(url)
@@ -80,3 +68,4 @@ class PancakeSwapAPI:
         """
         url = f"{self.base_url}pairs"
         return self.__get(url)
+        


### PR DESCRIPTION
Changes:

~~- Added `__enter__ ()` to complete the code needed for [with statement](https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers).~~
- [@line 25](https://github.com/scottburlovich/pythonpancakes/blob/014899227700e3dcc81ab407147a8ccd89aea5d0/src/pythonpancakes/api.py#L25) Removed the `try` block for `session.get` as it simply raises error straight after.
- [@line 30](https://github.com/scottburlovich/pythonpancakes/blob/014899227700e3dcc81ab407147a8ccd89aea5d0/src/pythonpancakes/api.py#L30) Removed the `try` block. See #3 .
- [@line 57](https://github.com/scottburlovich/pythonpancakes/blob/014899227700e3dcc81ab407147a8ccd89aea5d0/src/pythonpancakes/api.py#L57) Removed the `try` block. Also see [comment](https://github.com/scottburlovich/pythonpancakes/issues/3#issuecomment-885906732).