### PR TITLE
Simplified __get

### DIFF
--- a/src/pythonpancakes/api.py
+++ b/src/pythonpancakes/api.py
@@ -21,10 +21,9 @@ class PancakeSwapAPI:
         GET request wrapper
         :param request_url: str
         """
-        with requests.Session() as session:
-            response = session.get(request_url, timeout=self.request_timeout)
-            response.raise_for_status()
-            return json.loads(response.content.decode('utf-8'))
+        response = requests.get(request_url, timeout=self.request_timeout)
+        response.raise_for_status()
+        return json.loads(response.content.decode('utf-8'))
 
     def summary(self):
         """


### PR DESCRIPTION
We can use [requests.get()](https://github.com/psf/requests/blob/b227e3cb82c8d42ea27790d615ecafe12528d3bc/requests/api.py#L64) for a single get request. 

